### PR TITLE
Removes broke PR testing and deploys on release

### DIFF
--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -14,13 +14,13 @@ on:
       - deleted
 
 jobs:
-  archive:
-    name: Archive Envoy® Release
+  redeploy:
+    name: Redeploy archive-envoy.netlify.app (https://archive.tetratelabs.io/envoy)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Redeploy archive-envoy.netlify.app (https://archive.tetratelabs.io/envoy)
+      - name: Run Netlify Deploy
         uses: netlify/actions/cli@master
         env:  # https://github.com/tetratelabs/archive-envoy/settings/secrets
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}  # https://app.netlify.com/user/applications/personal

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -14,6 +14,7 @@ on:
       - deleted
 
 jobs:
+  # Automates "Trigger Deploy" on https://app.netlify.com/sites/archive-envoy/deploys to avoid manual steps
   redeploy:
     name: Redeploy archive-envoy.netlify.app (https://archive.tetratelabs.io/envoy)
     runs-on: ubuntu-latest
@@ -22,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Netlify Deploy
         uses: netlify/actions/cli@master
-        env:  # https://github.com/tetratelabs/archive-envoy/settings/secrets
+        env: # https://github.com/tetratelabs/archive-envoy/settings/secrets
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}  # https://app.netlify.com/user/applications/personal
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}  # .netlify/state.json/siteId
         with:

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -1,0 +1,29 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/redeploy.yaml
+---
+name: "redeploy"
+
+on:
+  delete:  # just in case a release was deleted via its tag
+    tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v1.18.3
+  release:
+    types:
+      - edited
+      - published
+      - deleted
+
+jobs:
+  archive:
+    name: Archive Envoy® Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Redeploy archive-envoy.netlify.app (https://archive.tetratelabs.io/envoy)
+        uses: netlify/actions/cli@master
+        env:  # https://github.com/tetratelabs/archive-envoy/settings/secrets
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}  # https://app.netlify.com/user/applications/personal
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}  # .netlify/state.json/siteId
+        with:
+          args: deploy --prod

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,3 @@
 #!/bin/sh -uex
 downloadBaseURL="${1?-downloadBaseURL required ex https://archive.tetratelabs.io/envoy}"
-
 bin/consolidate_release_versions.sh tetratelabs/archive-envoy "${downloadBaseURL}" >public/envoy-versions.json
-
-testURL=${2:-}
-[ "${testURL}" = '' ] && exit 0
-
-# Ensure we have tools we need installed
-export PATH=bin:$PATH
-getenvoy -v >/dev/null 2>&1 || curl -sSL https://getenvoy.io/install.sh | sh -s
-
-# test getenvoy with the generated version list
-export ENVOY_VERSIONS_URL="${testURL}/envoy-versions.json"
-getenvoy versions -a
-getenvoy run --version

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,9 +4,9 @@ publish = "public"
 
 [context]
 [context.branch-deploy]
-command = "./build.sh https://archive.tetratelabs.io/envoy/download ${DEPLOY_PRIME_URL}"
+command = "./build.sh https://archive.tetratelabs.io/envoy/download"
 [context.deploy-preview]
-command = "./build.sh ${DEPLOY_PRIME_URL}/download ${DEPLOY_PRIME_URL}"
+command = "./build.sh ${DEPLOY_PRIME_URL}/download"
 
 # ex https://archive.tetratelabs.io/envoy/download/v1.12.2/envoy-v1.12.2-linux-amd64.tar.xz
 # -> https://archive-envoy.netlify.app/download/v1.12.2/envoy-v1.12.2-linux-amd64.tar.xz


### PR DESCRIPTION
This allows us to drive everything by `git tag v1.18.3; git push origin v1.18.3`, until that is also automatic