### PR TITLE
Fixes date expression used by touch

### DIFF
--- a/bin/archive_release_version.sh
+++ b/bin/archive_release_version.sh
@@ -126,4 +126,5 @@ done
 releaseVersions=$(echo "${releaseVersions}" | jq '{latestVersion: .latestVersion, versions: .versions, sha256sums: .sha256sums}')
 # Write the versions file and reset file date as if they were published at the same time
 echo "${releaseVersions}" >"${version}/${name}-${version}.json"
-find "${version}" -exec touch -t "${RELEASE_DATE}" {} \;
+touchDate=$(echo "${RELEASE_DATE}"|sed 's/-//g')
+find "${version}" -exec touch -t "${touchDate}" {} \;


### PR DESCRIPTION
2021-05-11 works in darwin, but in linux it does this:
`touch: invalid date format ‘2021-05-11’`