### PR TITLE
Temporarily sets version to 1.18.3 until os/x build is fixed

### DIFF
--- a/bin/consolidate_release_versions.sh
+++ b/bin/consolidate_release_versions.sh
@@ -50,4 +50,5 @@ for version in ${versions}; do
 done
 
 # reorder top-level keys so that versions appear before sha256sums
-echo "${releaseVersions}" | jq '{latestVersion: .latestVersion, versions: .versions, sha256sums: .sha256sums}'
+# temporarily hard-code v1.18.3 until 1.19.0 is fixed https://github.com/Homebrew/homebrew-core/pull/81490
+echo "${releaseVersions}" | jq '{latestVersion: "1.18.3", versions: .versions, sha256sums: .sha256sums}'


### PR DESCRIPTION
This is tech debt, but the least tech debt way I can think of until envoy 1+ week version skew become normal.