### PR TITLE
Adds homebrew bump automation

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,45 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/bump.yaml
+---
+name: bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: Homebrew formula. Ex envoy or envoy@1.18
+        required: true
+      tag-name:
+        description: Release tag of envoy. Ex v1.18.5
+        required: true
+
+# These pull requests create pull requests against a remote repository. This implies the following:
+#  1. Create TOKEN with "public_repo" scope https://github.com/settings/tokens
+#  2. Assign that as PACKAGE_BUMP_TOKEN https://github.com/organizations/tetratelabs/settings/secrets/actions/new
+#
+# To ensure PRs appear non-personal, use an org-specific name and the noreply email of tetratelabs
+# Ex. curl -s https://api.github.com/users/tetratelabs|jq '.id, .login'
+env:
+  GIT_USER_NAME: Tetrate Labs CI
+  GIT_USER_EMAIL: 38483186+tetratelabs@users.noreply.github.com
+  GIT_COMMITTER: Tetrate Labs CI <38483186+tetratelabs@users.noreply.github.com>
+
+jobs:
+  homebrew:  # help ourselves until https://github.com/envoyproxy/envoy/issues/17500
+    name: "Homebrew/homebrew-core"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Configure git"
+        run: |
+          git config --global user.name "${GIT_USER_NAME}"
+          git config --global user.email "${GIT_USER_EMAIL}"
+
+      - name: "Bump Formula PR"
+        # Same as: brew bump-formula-pr --no-browse --no-audit --version "${tag-name}" "${formula}"
+        uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          formula-name: ${{ github.event.inputs.formula }}
+          tag-name: ${{ github.event.inputs.tag-name }}
+        env:  # See env section for notes on PACKAGE_BUMP_TOKEN
+          COMMITTER_TOKEN: ${{ secrets.PACKAGE_BUMP_TOKEN }}

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -1,8 +1,8 @@
 # `name` value will appear "as is" in the badge.
 # See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
-# yamllint --format github .github/workflows/bump.yaml
+# yamllint --format github .github/workflows/homebrew.yaml
 ---
-name: bump
+name: homebrew
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This helps us complete patch releases since Envoy aren't actually doing
it, yet.

See https://github.com/envoyproxy/envoy/issues/17500