### PR TITLE
Handles drift due from Envoy minor upgrade

### DIFF
--- a/bin/car_envoy.sh
+++ b/bin/car_envoy.sh
@@ -71,15 +71,15 @@ darwin) # https://github.com/Homebrew/homebrew-core/blob/master/Formula/envoy.rb
   # curl -fsSL -H 'Authorization: Bearer QQ==' 'https://ghcr.io/v2/homebrew/core/envoy/tags/list?n=10
   # curl -fsSL -H 'Authorization: Bearer QQ==' 'https://ghcr.io/v2/homebrew/core/envoy/1.17/tags/list?n=10
   case ${v} in
-  1.18.3)
-    reference=ghcr.io/homebrew/core/envoy:1.18.3-1
-    ${car} --strip-components 2 -qf "${reference}" envoy/${v}/bin/envoy
-    ;;
   1.17.*)
     reference=ghcr.io/homebrew/core/envoy/1.17:${v}
     ${car} --strip-components 2 -qf "${reference}" 'envoy@1.17'/${v}/bin/envoy
     ;;
-  *) # current version
+  1.18.*)
+    reference=ghcr.io/homebrew/core/envoy/1.18:${v}
+    ${car} --strip-components 2 -qf "${reference}" 'envoy@1.18'/${v}/bin/envoy
+    ;;
+  *) # current version 1.19
     reference=ghcr.io/homebrew/core/envoy:${v}
     ${car} --strip-components 2 -qf "${reference}" envoy/${v}/bin/envoy
     ;;


### PR DESCRIPTION
Homebrew uses versioned filed for non-current releases. When we released
1.19, we forgot to make the change here.

Note: this kills the special-casing for 1.18.3 as versions age out in
Homebrew anyway.

See https://github.com/Homebrew/homebrew-core/commit/aca3d99f59b4dd7e3120c6b0086307ddf41e3ca6

Signed-off-by: Adrian Cole <adrian@tetrate.io>