### PR TITLE
Do not verify Envoy images on macOS 10.15 and 11.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,8 +64,6 @@ jobs:
         include:
           - os: ubuntu-18.04
           - os: ubuntu-20.04
-          - os: macos-10.15
-          - os: macos-11
           - os: macos-12
           - os: windows-2019
           - os: windows-2022


### PR DESCRIPTION
After release 1.21.1, Envoy images build on macOS 12 cannot be run on previous releases.

GHA will not run verification for macOS 10.15 and 11.

Signed-off-by: Christoph Pakulski <christoph@tetrate.io>

Fixes: #41 