### PR TITLE
Remove support-and-testing for ubuntu-18.04, add ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,8 @@ jobs:
         # as Envoy requires newer versions of libc. The point of these tests are only to ensure the tarball wasn't corrupted
         # or built for the wrong platform.
         include:
-          - os: ubuntu-20.04 # the envoy 1.24.0 is the earliest to support this.
+          # - os: ubuntu-18.04 # Envoy 1.23.x is the last Envoy version that runs on ubuntu-18.04.
+          - os: ubuntu-20.04 # Envoy 1.24.x requires minimally ubuntu-20.04.
           - os: ubuntu-22.04
           - os: macos-12
           - os: windows-2019

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,6 @@ jobs:
         # Non-deprecated from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         # Note: We don't test arm64 on release as it is unlikely to fail and too much effort.
         include:
-          - os: ubuntu-18.04
           - os: ubuntu-20.04
           - os: macos-12
           - os: windows-2019

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,13 @@ jobs:
       matrix:
         # Non-deprecated from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         # Note: We don't test arm64 on release as it is unlikely to fail and too much effort.
+        #
+        # Operating systems in this matrix can run recent versions of Envoy. This needs maintenance
+        # as Envoy requires newer versions of libc. The point of these tests are only to ensure the tarball wasn't corrupted
+        # or built for the wrong platform.
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04 # the envoy 1.24.0 is the earliest to support this.
+          - os: ubuntu-22.04
           - os: macos-12
           - os: windows-2019
           - os: windows-2022


### PR DESCRIPTION
Since 1.24.0, envoy requires a newer `glibc`:

```
./envoy: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./envoy)
./envoy: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by ./envoy)
```

Corresponding CI run: https://github.com/tetratelabs/archive-envoy/actions/runs/3500591896/jobs/5863455940.

We could install a newer `glibc` on `/opt` and do `patchelf` but probably too complicated.

Reference: https://github.com/envoyproxy/envoy/blob/1647d3613d4a23467daaf067c906772e17e8bd3a/ci/README.md#build-image-base-and-compiler-versions envoy build image for Linux uses ubuntu-20.04.

This PR removes running tests on ubuntu-18.04 and adds ubuntu-22.04. Consequently, we skip supporting and testing Envoy on platforms before ubuntu-22.04.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>