### PR TITLE
Add check releases workflow 

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,26 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/release.yaml
+---
+name: "check"
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # https://crontab.guru/#0_0_*_*_*
+  workflow_dispatch:
+
+defaults:
+  run:  # use bash for all operating systems unless overridden
+    shell: bash
+
+jobs:
+  check:
+    name: "Check Envoy® Releases"
+    runs-on: ubuntu-20.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+      - name: "Check Envoy releases"
+        run: ./bin/check_releases.sh envoyproxy/envoy tetratelabs/archive-envoy
+        env:  # Set the gh's GH_TOKEN. See: https://cli.github.com/manual/gh_help_environment.
+          GH_TOKEN: ${{ secrets.PACKAGE_BUMP_TOKEN }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,9 +5,12 @@
 name: "check"
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # https://crontab.guru/#0_0_*_*_*
-  workflow_dispatch:
+  push:
+    branches:
+      - check-release
+  # schedule:
+  #   - cron: '0 0 * * *' # https://crontab.guru/#0_0_*_*_*
+  # workflow_dispatch:
 
 defaults:
   run:  # use bash for all operating systems unless overridden

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
       - name: "Check Envoy releases"
-        run: ./bin/check_releases.sh envoyproxy/envoy tetratelabs/archive-envoy
+        run: | # we set 1.18.1 as the lowest version to check because before that, some of the versions did not have published images.
+          lowest_version_to_check=1.18.1
+          ./bin/check_releases.sh envoyproxy/envoy tetratelabs/archive-envoy ${lowest_version_to_check}
         env:  # Set the gh's GH_TOKEN. See: https://cli.github.com/manual/gh_help_environment.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,12 +5,11 @@
 name: "check"
 
 on:
-  push:
-    branches:
-      - check-release
-  # schedule:
-  #   - cron: '0 0 * * *' # https://crontab.guru/#0_0_*_*_*
-  # workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # https://crontab.guru/#0_0_*_*_*
+
+  # Allows triggering the workflow manually in github actions page.
+  workflow_dispatch:
 
 defaults:
   run:  # use bash for all operating systems unless overridden

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: "Check Envoy releases"
         run: ./bin/check_releases.sh envoyproxy/envoy tetratelabs/archive-envoy
         env:  # Set the gh's GH_TOKEN. See: https://cli.github.com/manual/gh_help_environment.
-          GH_TOKEN: ${{ secrets.PACKAGE_BUMP_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/bin/check_releases.sh
+++ b/bin/check_releases.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ue
+
+# Ensure we have tools we need installed
+curl --version >/dev/null
+jq --version >/dev/null
+gh --version >/dev/null
+
+sourceGitHubRepository=${1?sourceGitHubRepository is required. ex envoyproxy/envoy}
+targetGitHubRepository=${2?targetGitHubRepository is required. ex tetratelabs/archive-envoy}
+
+curl="curl -fsSL"
+
+# A valid GitHub token to avoid rate limiting.
+githubToken=${GITHUB_TOKEN:-}
+# Prepare authorization header when performing request to api.github.com to avoid rate limiting, especially when testing locally.
+authorizationHeader="Authorization: Bearer ${githubToken}"
+
+# Always use the released versions.
+currentVersions=$(${curl} https://archive.tetratelabs.io/envoy/envoy-versions.json)
+
+# Fetch the last page number of releases (example value: 7), so we can get all of the releases.
+# To get the last page, we send a HEAD request to "https://api.github.com/repos/${sourceGitHubRepository}/releases",
+# then "grep" the "link" header value.
+# Reference: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers.
+lastReleasePage=$(${curl}I ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${sourceGitHubRepository}/releases" |
+  grep -Eo 'page=[0-9]+' | awk 'NR==2' | cut -d'=' -f2) || exit 1
+
+for ((page = 1; page <= lastReleasePage; page++)); do
+  versions=$(${curl} ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${sourceGitHubRepository}/releases?page=${page}" |
+    jq -er ".|map(select(.prerelease == false and .draft == false))|.[]|.name" | sort -n) || exit 1
+
+  for version in ${versions}; do
+    if [[ $(echo "${currentVersions}" | jq -r --arg ver "${version#v}" '.versions | has($ver)') == "true" ]]; then
+      continue
+    fi
+
+    if [[ "$(echo -e "${version#v}\n1.12.0" | sort -V | tail -n 1)" == "${version#v}" ]]; then
+      echo "creating release for"' '"${version}"
+      gh workflow run release.yaml -f version="${version}"_debug -R "${targetGitHubRepository}"
+      gh workflow run release.yaml -f version="${version}" -R "${targetGitHubRepository}"
+    fi
+
+    # TODO(dio): For macOS, we still need to check for https://ghcr.io/v2/homebrew/core/envoy/tags/list and see if
+    # our released JSON has darwin tarballs in it.
+  done
+done

--- a/bin/check_releases.sh
+++ b/bin/check_releases.sh
@@ -16,6 +16,9 @@
 
 set -ue
 
+# This checks upstrean ${sourceGitHubRepository} releases and compares it
+# with the released versions on https://archive.tetratelabs.io/envoy/envoy-versions.json.
+
 # Ensure we have tools we need installed
 curl --version >/dev/null
 jq --version >/dev/null
@@ -23,6 +26,7 @@ gh --version >/dev/null
 
 sourceGitHubRepository=${1?sourceGitHubRepository is required. ex envoyproxy/envoy}
 targetGitHubRepository=${2?targetGitHubRepository is required. ex tetratelabs/archive-envoy}
+lowestVersion=${3?lowestVersion is required. ex 12.0.0}
 
 curl="curl -fsSL"
 
@@ -50,7 +54,7 @@ for ((page = 1; page <= lastReleasePage; page++)); do
       continue
     fi
 
-    if [[ "$(echo -e "${version#v}\n1.12.0" | sort -V | tail -n 1)" == "${version#v}" ]]; then
+    if [[ "$(echo -e "${version#v}\n${lowestVersion}" | sort -V | tail -n 1)" == "${version#v}" ]]; then
       echo "creating release for"' '"${version}"
       gh workflow run release.yaml -f version="${version}"_debug -R "${targetGitHubRepository}"
       gh workflow run release.yaml -f version="${version}" -R "${targetGitHubRepository}"


### PR DESCRIPTION
This adds a scheduled workflow that checks envoy releases from upstream and sees if we missed some of the versions in our https://archive.tetratelabs.io/envoy/envoy-versions.json.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>