### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
           # - os: ubuntu-18.04 # Envoy 1.23.x is the last Envoy version that runs on ubuntu-18.04.
           - os: ubuntu-20.04 # Envoy 1.24.x requires minimally ubuntu-20.04.
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-latest
           - os: windows-2019
           - os: windows-2022
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,8 +70,6 @@ jobs:
           - os: ubuntu-20.04 # Envoy 1.24.x requires minimally ubuntu-20.04.
           - os: ubuntu-22.04
           - os: macos-latest
-          - os: windows-2019
-          - os: windows-2022
 
     steps:
       - name: "Extract `envoy` binary from GitHub release assets"


### PR DESCRIPTION
* Updates the macos image (12 was not available anymore)
* Deletes the windows test (Envoy no longer supports Windows)