### PR TITLE
Enable WASM for macOS builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
             --action_env=CXX=${CXX}
             --host_action_env=CC=${CC}
             --host_action_env=CXX=${CXX}
-            --macos_minimum_os=10.15
+            --macos_minimum_os=${MACOSX_DEPLOYMENT_TARGET}
           )
 
           # if Clang ≥17, disable the new missing-template-arg-list warning

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
         run: |
           brew update
           brew install automake cmake libtool ninja bazelisk python@3.9 coreutils llvm@18
+          echo "$(brew --prefix coreutils)/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Set up LLVM-18 clang/clang++ on PATH
         if: ${{ !endsWith(github.event.inputs.version, '_debug') }}
@@ -55,6 +56,7 @@ jobs:
       - name: Build envoy-static
         if: ${{ !endsWith(github.event.inputs.version, '_debug') }}
         run: |
+          export MACOSX_DEPLOYMENT_TARGET=10.15
           # locate bazelisk
           BAZELISK=$(brew --prefix bazelisk)/bin/bazelisk
 
@@ -63,13 +65,14 @@ jobs:
             --compilation_mode=opt
             --curses=no
             --verbose_failures
-            --define=wasm=disabled
+            --define=wasm=enabled
             --copt=-Wno-unused-but-set-variable
             --config=clang
             --action_env=CC=${CC}
             --action_env=CXX=${CXX}
             --host_action_env=CC=${CC}
             --host_action_env=CXX=${CXX}
+            --macos_minimum_os=10.15
           )
 
           # if Clang ≥17, disable the new missing-template-arg-list warning


### PR DESCRIPTION
This changes the release workflow to enable wasm on MacOS envoy builds. To do so, this updates the minimum MacOS version to 14.5, which corresponds to the upstream minimum, and allows access to newer APIs like `aligned_alloc`. Until we do this, we have no nice way to use MacOS without docker, and with such a small change needed, we should just do it.

I tested this locally and it works fine, but if there's some slight glitch in the workflow, might need a follow-up.