### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @tetratelabs/func-e-owners


### PR DESCRIPTION
This repo is tightly related to func-e, and it makes sense that it has the same ownership.