### PR TITLE
Adds nightly dev release pipeline

### DIFF
--- a/.github/actions/test-envoy/action.yaml
+++ b/.github/actions/test-envoy/action.yaml
@@ -1,0 +1,20 @@
+name: "Test Envoy binary"
+description: "Download a release tarball and verify the binary runs"
+inputs:
+  version:
+    description: "Release tag to download"
+    required: true
+  pattern:
+    description: "Asset glob pattern"
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release -R "${GITHUB_REPOSITORY}" download "${{ inputs.version }}" -p "${{ inputs.pattern }}"
+        tar --strip-components=2 -xpJf ./*.tar.xz && rm ./*.tar.xz
+    - shell: bash
+      run: ./envoy --version

--- a/.github/workflows/archive-release.yaml
+++ b/.github/workflows/archive-release.yaml
@@ -9,10 +9,18 @@ on:  # yamllint disable-line rule:truthy
         description: "Release version tag"
         type: string
         required: true
-      include_macos:
-        description: "Include the macOS artifact"
-        type: boolean
+      os:
+        description: "OS to archive (linux or darwin)"
+        type: string
         required: true
+      envoy_sha:
+        description: "Envoy commit SHA for dev builds"
+        type: string
+        default: ""
+      prerelease:
+        description: "Mark as prerelease and overwrite existing"
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -27,9 +35,11 @@ jobs:
     permissions:
       contents: write
     env:
+      GH_TOKEN: ${{ github.token }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       VERSION: ${{ inputs.version }}
+      ENVOY_SHA: ${{ inputs.envoy_sha }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -40,7 +50,7 @@ jobs:
           go-version: "1.24"
 
       - name: "Download macOS Apple Silicon binary"
-        if: ${{ inputs.include_macos }}
+        if: inputs.os == 'darwin'
         uses: actions/download-artifact@v4
         with:
           name: "envoy-${{ inputs.version }}-\
@@ -49,12 +59,14 @@ jobs:
             ${{ inputs.version }}-darwin-arm64/bin"
 
       - name: "Mark macOS binary as executable"
-        if: ${{ inputs.include_macos }}
+        if: inputs.os == 'darwin'
         run: >-
           chmod +x
           "${VERSION}"/envoy-"${VERSION}"-darwin-arm64/bin/envoy
 
       - name: "Archive Envoy Release"
+        env:
+          ARCHIVE_OS: ${{ inputs.os }}
         run: >-
           ./bin/archive_release_version.sh
           envoyproxy/envoy "${VERSION}"
@@ -63,7 +75,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.version }}
+          prerelease: ${{ inputs.prerelease }}
           files: ${{ inputs.version }}/*
+          body: >-
+            ${{ inputs.envoy_sha != ''
+            && format('envoy_sha={0}', inputs.envoy_sha)
+            || '' }}
 
       - name: "Trigger Netlify deploy"
         if: >-

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -1,0 +1,75 @@
+# yamllint --format github .github/workflows/build-macos.yaml
+---
+name: "build-macos"
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out (tag or SHA)"
+        type: string
+        required: true
+      compilation_mode:
+        description: "Bazel compilation mode (opt or dbg)"
+        type: string
+        default: "opt"
+      artifact_name:
+        description: "Name for the uploaded artifact"
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: "build"
+    runs-on: macos-15-xlarge
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: "Check out Envoy source"
+        uses: actions/checkout@v4
+        with:
+          repository: envoyproxy/envoy
+          ref: ${{ inputs.ref }}
+
+      - uses: bazel-contrib/setup-bazel@0.18.0
+
+      - name: "Configure GitHub auth for Bazel downloads"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf 'machine github.com\nlogin x-access-token\npassword %s\n' "${GITHUB_TOKEN}" >> ~/.netrc
+          printf 'machine codeload.github.com\nlogin x-access-token\npassword %s\n' "${GITHUB_TOKEN}" >> ~/.netrc
+          chmod 600 ~/.netrc
+
+      - name: "Build envoy-static"
+        run: |
+          ARGS=(
+            "--compilation_mode=${{ inputs.compilation_mode }}"
+            --curses=no
+            --verbose_failures
+            "--linkopt=-Wl,-framework,SystemConfiguration"
+          )
+
+          bazel build "${ARGS[@]}" //source/exe:envoy-static
+
+          mkdir -p bin
+          mv bazel-bin/source/exe/envoy-static bin/envoy
+          chmod u+w bin/envoy
+          strip bin/envoy
+
+      - name: "Publish attestation to GitHub"
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: bin/envoy
+
+      - name: "Upload Envoy binary"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: bin/envoy

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,33 +1,62 @@
-# `name` value will appear "as is" in the badge.
-# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
-# yamllint --format github .github/workflows/release.yaml
+# yamllint --format github .github/workflows/nightly.yaml
 ---
-name: "release"
+name: "nightly"
 
 on:
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
     inputs:
       version:
-        description: Version of the release. Ex v1.34.1 or v1.34.1_debug
-        required: true
+        description: 'Version to build (dev or dev_debug)'
+        type: choice
+        options:
+          - dev
+          - dev_debug
+        default: dev
+
+concurrency:
+  group: nightly-${{ inputs.version || 'trigger' }}
+  cancel-in-progress: true
 
 defaults:
-  run: # use bash for all operating systems unless overridden
+  run:
     shell: bash
 
 jobs:
+  trigger:
+    name: "trigger"
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - run: |
+          gh workflow run nightly.yaml -f version=dev
+          gh workflow run nightly.yaml -f version=dev_debug
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
   resolve:
     name: "resolve"
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     outputs:
       ref: ${{ steps.resolve.outputs.ref }}
       compilation_mode: ${{ steps.resolve.outputs.compilation_mode }}
     steps:
-      - name: "Resolve release inputs"
+      - uses: actions/checkout@v4
+
+      - name: "Resolve inputs"
         id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="${{ github.event.inputs.version }}"
-          echo "ref=${version%_debug}" >> "$GITHUB_OUTPUT"
+          ref=$(./bin/resolve_envoy_sha.sh)
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+          version="${{ inputs.version }}"
           if [[ "${version}" == *_debug ]]; then
             echo "compilation_mode=dbg" >> "$GITHUB_OUTPUT"
           else
@@ -41,27 +70,31 @@ jobs:
     with:
       ref: ${{ needs.resolve.outputs.ref }}
       compilation_mode: ${{ needs.resolve.outputs.compilation_mode }}
-      artifact_name: envoy-${{ github.event.inputs.version }}-darwin-arm64
+      artifact_name: envoy-${{ inputs.version }}-darwin-arm64
     secrets: inherit
 
   archive-linux:
     name: "archive (linux)"
+    needs: resolve
     uses: ./.github/workflows/archive-release.yaml
     with:
-      version: ${{ github.event.inputs.version }}
+      version: ${{ inputs.version }}
       os: linux
+      envoy_sha: ${{ needs.resolve.outputs.ref }}
+      prerelease: true
     secrets: inherit
 
   archive-macos:
     name: "archive (macos)"
-    needs: build-envoy-macos
+    needs: [resolve, build-envoy-macos]
     uses: ./.github/workflows/archive-release.yaml
     with:
-      version: ${{ github.event.inputs.version }}
+      version: ${{ inputs.version }}
       os: darwin
+      envoy_sha: ${{ needs.resolve.outputs.ref }}
+      prerelease: true
     secrets: inherit
 
-  # Smoke tests run after publishing so uploads are not blocked by test failures.
   test-linux:
     name: "test (linux)"
     needs: archive-linux
@@ -70,16 +103,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-envoy
         with:
-          version: ${{ github.event.inputs.version }}
+          version: ${{ inputs.version }}
           pattern: "*-linux-amd64.tar.xz"
 
   test-macos:
     name: "test (macos)"
     needs: archive-macos
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-envoy
         with:
-          version: ${{ github.event.inputs.version }}
+          version: ${{ inputs.version }}
           pattern: "*-darwin-arm64.tar.xz"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 # any version directories
 /v*
+/dev
+/dev_debug
 
 # generated at build time
 public/envoy-versions*.json

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,30 @@
+# Notable rationale of archive-envoy
+
+## Why is macOS built from source?
+
+Envoy publishes Docker images for Linux only. macOS binaries are built from
+source by checking out envoyproxy/envoy and building with Bazel. Linux
+tarballs are archived independently of the macOS build, so they still
+publish when the macOS build fails.
+
+For nightly builds, there is no release tag to check out. We resolve the
+commit SHA from Envoy's last successful [Publish & verify][envoy-publish]
+run, which is the commit whose images exist on [Docker Hub][dockerhub-dev].
+
+## Why do we use a top-level "dev" key for nightly builds?
+
+`dev` is not a semver version and carries `commitSha` instead of a version
+number. Putting it inside `"versions"` would break existing consumers that
+parse semver-keyed entries. A separate top-level `"dev"` key means consumers
+are unaffected unless they opt in.
+
+A single `dev` release overwrites daily, so there is only ever one dev build.
+You cannot reinstall an older nightly or have parallel dev builds for different
+branches. This keeps release count and maintenance bounded, and avoids
+notifying repository watchers daily.
+
+
+---
+[envoy-publish]: https://github.com/envoyproxy/envoy/blob/main/.github/workflows/envoy-publish.yml
+[dockerhub-dev]: https://hub.docker.com/r/envoyproxy/envoy/tags?name=dev-
+[dockerhub-debug-dev]: https://hub.docker.com/r/envoyproxy/envoy/tags?name=debug-dev-

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ which adheres to the [release versions schema](https://archive.tetratelabs.io/re
 Specifically, releases include a tarball per platform with exactly the same binary as what users would have, if
 they used Docker or Homebrew instructions from here: https://www.envoyproxy.io/docs/envoy/latest/start/install
 
+## Dev releases
+A [nightly workflow](.github/workflows/nightly.yaml) builds dev tarballs from Envoy's `main` branch daily.
+These appear as a top-level `"dev"` key in [envoy-versions.json](https://archive.tetratelabs.io/envoy/envoy-versions.json)
+and [envoy-versions_debug.json](https://archive.tetratelabs.io/envoy/envoy-versions_debug.json), alongside the existing
+`"versions"` key. Consumers that don't read `"dev"` are unaffected.
+
 ## Standard releases
 A standard release includes `envoy-$version-$os-$arch.tar.xz` for every platform, including a production, non_debug,
 binary.

--- a/bin/archive_release_version.sh
+++ b/bin/archive_release_version.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Tetrate
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright Archive Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
 
 set -ue
 
@@ -43,6 +34,11 @@ set -ue
 sourceGitHubRepository=${1?sourceGitHubRepository is required. ex envoyproxy/envoy}
 name=$(basename "${sourceGitHubRepository}") || exit 1
 case "${2:-}" in
+dev|dev_debug)
+  [ -z "${ENVOY_SHA:-}" ] && echo >&2 "ENVOY_SHA required for dev builds" && exit 1
+  version=$2
+  sourceVersion=${version%_debug}
+  ;;
 v[0-9]*[0-9]_debug|v[0-9]*[0-9])
   version=$2
   sourceVersion=${version%_debug}
@@ -83,6 +79,14 @@ authorizationHeader="Authorization: Bearer ${githubToken}"
 # Setup defaults that make archival consistent between runs
 export TZ=UTC
 
+# Dev builds resolve the release date from the commit
+if [ -n "${ENVOY_SHA:-}" ]; then
+  envoy_sha=${ENVOY_SHA}
+  RELEASE_DATE=$(${curl} ${githubToken:+ -H "${authorizationHeader}"} \
+    "https://api.github.com/repos/${sourceGitHubRepository}/commits/${envoy_sha}" |
+    jq -er '.commit.committer.date' | cut -c1-10) || exit 1
+else
+
 # Fetch the last page number of releases (example value: 7), so we can get all of the releases.
 # To get the last page, we send a HEAD request to "https://api.github.com/repos/${sourceGitHubRepository}/releases",
 # then "grep" the "link" header value.
@@ -104,14 +108,24 @@ if [ "${RELEASE_DATE}" = "null" ]; then
   echo >&2 "version ${sourceVersion} has not yet been released" && exit 1
 fi
 
+fi
+
 export RELEASE_DATE
 tarxz="${tar} --numeric-owner --owner 65534 --group 65534 --mtime ${RELEASE_DATE?-ex. 2021-05-11} -cpJf"
 
 echo "archiving ${sourceGitHubRepository} ${version} released on ${RELEASE_DATE}"
 # archive all dists for the version, generating https://archive.tetratelabs.io/release-versions-schema.json incrementally
 releaseVersions="{}"
+archiveRepo=${GITHUB_REPOSITORY:-tetratelabs/archive-envoy}
+
+# ARCHIVE_OS filters to a single OS when set (used by split lanes).
+archiveOS=${ARCHIVE_OS:-}
+
 for os in darwin linux; do
-  for arch in amd64 arm64; do
+  [ -n "${archiveOS}" ] && [ "${os}" != "${archiveOS}" ] && continue
+  for arch in arm64 amd64; do
+    [ "${os}" = 'darwin' ] && [ "${arch}" = 'amd64' ] && continue
+
     dist="envoy-${version}-${os}-${arch}"
     echo "using dist: ${dist}"
 
@@ -127,7 +141,6 @@ for os in darwin linux; do
 
       if ! [ -d "${version}/${dist}" ]; then
         echo >&2 "expected to extract files for ${os}/${arch}" && exit 1
-        exit 1
       fi
     fi
 
@@ -137,11 +150,19 @@ for os in darwin linux; do
     rm -rf "${version}/${dist}"
     s=$(sha256sum "${version}/${archive}" | awk '{print $1}') || exit 1
 
-    # strip the v off the tag name more shell portable than ${version:1}
-    v=$(echo "${version}" | cut -c2-100)
     # use printf because jq doesn't support parameterizing the key names, only the key values
-    nextReleaseVersion=$(printf '{"latestVersion": "%s", "versions": { "%s": {"releaseDate": "%s", "tarballs": {"%s": "%s"}}}, "sha256sums": {"%s": "%s"}}' \
-      "$v" "$v" "${RELEASE_DATE}" "${os}/${arch}" "${archiveBaseUrl}/${archive}" "${archive}" "$s")
+    case ${version} in
+    dev|dev_debug)
+      nextReleaseVersion=$(printf '{"dev": {"releaseDate": "%s", "commitSha": "%s", "tarballs": {"%s": "%s"}}, "sha256sums": {"%s": "%s"}}' \
+        "${RELEASE_DATE}" "${envoy_sha}" "${os}/${arch}" "${archiveBaseUrl}/${archive}" "${archive}" "$s")
+      ;;
+    *)
+      # strip the v off the tag name more shell portable than ${version:1}
+      v=$(echo "${version}" | cut -c2-100)
+      nextReleaseVersion=$(printf '{"latestVersion": "%s", "versions": { "%s": {"releaseDate": "%s", "tarballs": {"%s": "%s"}}}, "sha256sums": {"%s": "%s"}}' \
+        "$v" "$v" "${RELEASE_DATE}" "${os}/${arch}" "${archiveBaseUrl}/${archive}" "${archive}" "$s")
+      ;;
+    esac
     # merge the pending releaseVersions json to include the next dist
     releaseVersions=$(echo "${releaseVersions}" "${nextReleaseVersion}" | jq -Sse '.[0] * .[1]')
   done
@@ -150,8 +171,22 @@ done
 [ "${op}" = 'check' ] && exit 0
 [ "${releaseVersions}" = '{}' ] && exit 1
 
-# reorder top-level keys so that versions appear before sha256sums
-releaseVersions=$(echo "${releaseVersions}" | jq '{latestVersion: .latestVersion, versions: .versions, sha256sums: .sha256sums}')
+# Seed from existing release JSON so split lanes merge into one file.
+# Done after archiving so the second lane to finish picks up the first lane's results.
+existing=$(gh release download "${version}" -R "${archiveRepo}" -p "${name}-${version}.json" -O - 2>/dev/null) || true
+if [ -n "${existing}" ]; then
+  releaseVersions=$(echo "${existing}" "${releaseVersions}" | jq -Sse '.[0] * .[1]')
+fi
+
+case ${version} in
+dev|dev_debug)
+  releaseVersions=$(echo "${releaseVersions}" | jq '{dev, sha256sums}')
+  ;;
+*)
+  # reorder top-level keys so that versions appear before sha256sums
+  releaseVersions=$(echo "${releaseVersions}" | jq '{latestVersion, versions, sha256sums}')
+  ;;
+esac
 # Write the versions file and reset file date as if they were published at the same time
 echo "${releaseVersions}" >"${version}/${name}-${version}.json"
 touchDate=$(echo "${RELEASE_DATE}"|sed 's/-//g')0000

--- a/bin/car_envoy.sh
+++ b/bin/car_envoy.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Tetrate
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright Archive Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
 
 set -ue
 
@@ -50,7 +41,7 @@ mode=${5?mode is required: list or extract}
 directory=${6:-}
 
 platform=${os}/${arch}
-case ${version} in v[0-9]*[0-9]_debug) debug="1" ;; esac
+case ${version} in v[0-9]*[0-9]_debug|dev_debug) debug="1" ;; esac
 
 if [ "${debug:-}" = '1' ] && [ "${os}" != 'linux' ]; then
   echo >&2 "debug not yet supported on ${os}" && exit 1
@@ -107,7 +98,16 @@ darwin) # https://github.com/Homebrew/homebrew-core/blob/master/Formula/envoy.rb
   ;;
 linux)
   files="usr/local/bin/envoy"
-  if [ "${debug:-}" = '1' ]; then
+  # Tags like dev-<SHA> and debug-dev-<SHA> are published by Envoy's "Publish & verify" workflow:
+  # https://github.com/envoyproxy/envoy/blob/main/.github/workflows/envoy-publish.yml
+  if [ -n "${ENVOY_SHA:-}" ]; then
+    if [ "${debug:-}" = '1' ]; then
+      reference=envoyproxy/envoy:debug-dev-${ENVOY_SHA}
+      files="$files usr/local/bin/envoy.dwp"
+    else
+      reference=envoyproxy/envoy:dev-${ENVOY_SHA}
+    fi
+  elif [ "${debug:-}" = '1' ]; then
     case ${sourceVersion} in
     # Legacy debug repository tags stop after v1.34.4, except v1.35.0.
     v1.1[6-9].*|v1.2[0-9].*|v1.3[0-3].*|v1.34.[0-4]|v1.35.0)

--- a/bin/check_releases.sh
+++ b/bin/check_releases.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Tetrate
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright Archive Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
 
 set -ue
 

--- a/bin/consolidate_release_versions.sh
+++ b/bin/consolidate_release_versions.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Tetrate
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright Archive Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
 
 set -ue
 
@@ -45,18 +36,20 @@ redirectsTo="https://github.com/${githubRepo}/releases/download"
 # then "grep" the "link" header value.
 # Reference: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers.
 lastReleasePage=$(${curl}I ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${githubRepo}/releases" |
-  grep -Eo 'page=[0-9]+' | awk 'NR==2' | cut -d'=' -f2) || exit 1
+  grep -Eo 'page=[0-9]+' | awk 'NR==2' | cut -d'=' -f2)
+lastReleasePage=${lastReleasePage:-1}
 
 # archive all dists for the version, generating the envoy-versions.json format incrementally
 releaseVersions="{}"
 
 for ((page = 1; page <= lastReleasePage; page++)); do
+  # dev and dev_debug are prereleases, so they need explicit name matching to pass the filter.
   versions=$(${curl} ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${githubRepo}/releases?page=${page}" |
-    jq -er ".|map(select(.prerelease == false and .draft == false))|.[]|.name" | sort -n) || exit 1
+    jq -er ".|map(select((.prerelease == false and .draft == false) or .name == \"dev\" or .name == \"dev_debug\"))|.[]|.name" | sort -n) || exit 1
 
   for version in ${versions}; do
     # Exclusively handle debug.
-    case ${version} in v[0-9]*[0-9]_debug) nextDebugVersion=1 ;; *) unset nextDebugVersion;; esac
+    case ${version} in v[0-9]*[0-9]_debug|dev_debug) nextDebugVersion=1 ;; *) unset nextDebugVersion;; esac
     [ "${debugVersion:-}" != "${nextDebugVersion:-}" ] && continue
 
     versionsUrl="${redirectsTo}/${version}/envoy-${version}.json"
@@ -69,4 +62,4 @@ done
 # reorder top-level keys so that versions appear before sha256sums
 echo "${releaseVersions}" |\
   jq '. | .latestVersion = ( .versions | keys | sort | .[-1] )' |\
-  jq '{latestVersion: .latestVersion, versions: .versions, sha256sums: .sha256sums}'
+  jq '{latestVersion, versions, sha256sums} + (if .dev then {dev} else {} end)'

--- a/bin/resolve_envoy_sha.sh
+++ b/bin/resolve_envoy_sha.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright Archive Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+set -ueo pipefail
+
+# Resolves the commit SHA from Envoy's last successful "Publish & verify" workflow run on main.
+# Don't use Docker Hub's tag listing API — its ordering reflects vulnerability rescans, not push time.
+# https://github.com/envoyproxy/envoy/blob/main/.github/workflows/envoy-publish.yml
+#
+# Outputs the 40-char SHA to stdout. Exits non-zero if it cannot be resolved.
+#
+# Optional environment:
+#   GH_TOKEN — GitHub token for authenticated API requests (avoids rate limiting)
+
+curl="curl -fsSL"
+authHeader=""
+if [ -n "${GH_TOKEN:-}" ]; then
+  authHeader="Authorization: Bearer ${GH_TOKEN}"
+fi
+
+envoy_sha=$(${curl} ${authHeader:+ -H "${authHeader}"} \
+  "https://api.github.com/repos/envoyproxy/envoy/actions/workflows/envoy-publish.yml/runs?branch=main&status=success&per_page=1" |
+  jq -r '.workflow_runs[0].head_sha')
+
+if [ -z "${envoy_sha}" ] || [ "${envoy_sha}" = "null" ]; then
+  echo >&2 "Could not resolve dev image SHA from Envoy publish workflow"
+  exit 1
+fi
+
+echo "${envoy_sha}"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 command = "./build.sh https://archive.tetratelabs.io/envoy/download"
 publish = "public"
 
+# tetratelabs org only allows up to 366 day expiration of tokens, even if read-only.
+# Before 2027-05-14, generate a read-only token for tetratelabs/archive-envoy here:
+# https://github.com/settings/personal-access-tokens Then, update GITHUB_TOKEN here:
+# https://app.netlify.com/projects/archive-envoy/configuration/env#environment-variables
 [context]
 [context.branch-deploy]
 command = "./build.sh https://archive.tetratelabs.io/envoy/download"


### PR DESCRIPTION
Build tarballs from Envoy's dev Docker images and macOS source daily. Expose as a top-level "dev" key in envoy-versions.json so func-e and other consumers can offer a dev channel without changing the existing schema.

Resolve the commit from Envoy's last successful publish workflow, then use that SHA for both linux (Docker pull) and macOS (source checkout + Bazel build).

Verified by running on my fork with a local macos runner:

```json
{
  "latestVersion": "1.38.0",
  "versions": {
    "1.38.0": {
      "releaseDate": "2026-04-23",
      "tarballs": {
        "darwin/arm64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/v1.38.0/envoy-v1.38.0-darwin-arm64.tar.xz",
        "linux/amd64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/v1.38.0/envoy-v1.38.0-linux-amd64.tar.xz",
        "linux/arm64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/v1.38.0/envoy-v1.38.0-linux-arm64.tar.xz"
      }
    }
  },
  "sha256sums": {
    "envoy-dev-darwin-arm64.tar.xz": "1c743cd8776b500f144a98486df93df199f1c2f8740d5cfced32de5fda25f2ac",
    "envoy-dev-linux-amd64.tar.xz": "f16a4b9239b4673591b4819704e8b47c0d9a3134f94f0caff1bf6411b6a32f47",
    "envoy-dev-linux-arm64.tar.xz": "bcdb1dc49617cd91d19989fc485b6e8d02a1b0f0e44a96aae31e2e2bde3ebbb8",
    "envoy-v1.38.0-darwin-arm64.tar.xz": "41e3e696e9826b8b7646b0e364b1816636c4fecc7e0321e5b1fb16909ae988b4",
    "envoy-v1.38.0-linux-amd64.tar.xz": "df73c7560095ac4fd8c592a93b2c1aa23c38f0e0bdf8661d75d7b71fa4788af8",
    "envoy-v1.38.0-linux-arm64.tar.xz": "afb2bd88783cece5530bdd01caf62e7b462867d449ab789ff9cbbf7d6a53e706"
  },
  "dev": {
    "commitSha": "abbadd905fa486ff1085cf3bbe4f3b73eb6dd8e0",
    "releaseDate": "2026-05-17",
    "tarballs": {
      "darwin/arm64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/dev/envoy-dev-darwin-arm64.tar.xz",
      "linux/amd64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/dev/envoy-dev-linux-amd64.tar.xz",
      "linux/arm64": "https://github.com/codefromthecrypt/archive-envoy/releases/download/dev/envoy-dev-linux-arm64.tar.xz"
    }
  }
}
```

Closes #12
