### PR TITLE
Test arm64 on release

### DIFF
--- a/.github/actions/test-envoy/action.yaml
+++ b/.github/actions/test-envoy/action.yaml
@@ -4,9 +4,6 @@ inputs:
   version:
     description: "Release tag to download"
     required: true
-  pattern:
-    description: "Asset glob pattern"
-    required: true
 runs:
   using: composite
   steps:
@@ -14,7 +11,17 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release -R "${GITHUB_REPOSITORY}" download "${{ inputs.version }}" -p "${{ inputs.pattern }}"
+        case "${{ runner.os }}" in
+          Linux)  os=linux  ;;
+          macOS)  os=darwin ;;
+        esac
+        case "${{ runner.arch }}" in
+          X64)    arch=amd64 ;;
+          ARM64)  arch=arm64 ;;
+        esac
+        pattern="*-${os}-${arch}.tar.xz"
+        gh release -R "${GITHUB_REPOSITORY}" download \
+          "${{ inputs.version }}" -p "${pattern}"
         tar --strip-components=2 -xpJf ./*.tar.xz && rm ./*.tar.xz
     - shell: bash
       run: ./envoy --version

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -96,23 +96,28 @@ jobs:
     secrets: inherit
 
   test-linux:
-    name: "test (linux)"
+    name: "test (linux ${{ matrix.arch }})"
     needs: archive-linux
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ inputs.version }}
-          pattern: "*-linux-amd64.tar.xz"
 
   test-macos:
     name: "test (macos)"
     needs: archive-macos
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-15-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ inputs.version }}
-          pattern: "*-darwin-arm64.tar.xz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,15 +63,21 @@ jobs:
 
   # Smoke tests run after publishing so uploads are not blocked by test failures.
   test-linux:
-    name: "test (linux)"
+    name: "test (linux ${{ matrix.arch }})"
     needs: archive-linux
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ github.event.inputs.version }}
-          pattern: "*-linux-amd64.tar.xz"
 
   test-macos:
     name: "test (macos)"
@@ -82,4 +88,3 @@ jobs:
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ github.event.inputs.version }}
-          pattern: "*-darwin-arm64.tar.xz"


### PR DESCRIPTION
GitHub now offers free arm64 Linux runners for public repos. Use a matrix in the linux test jobs to smoke-test both amd64 and arm64, and move OS/arch detection into the test-envoy action so callers only pass the version.

Closes #44