### PR TITLE
Fix lexicographic->semver for latestVersion

### DIFF
--- a/bin/consolidate_release_versions.sh
+++ b/bin/consolidate_release_versions.sh
@@ -61,5 +61,5 @@ done
 
 # reorder top-level keys so that versions appear before sha256sums
 echo "${releaseVersions}" |\
-  jq '. | .latestVersion = ( .versions | keys | sort | .[-1] )' |\
+  jq '. | .latestVersion = ( .versions | keys | sort_by(split(".") | map(tonumber)) | last )' |\
   jq '{latestVersion, versions, sha256sums} + (if .dev then {dev} else {} end)'


### PR DESCRIPTION
while unlikely for the last minor release of envoy to hit 10 patches before the next (or impossible really) this fixes an edge case.