### PR TITLE
Automates release archiving on new Envoy versions

### DIFF
--- a/.github/workflows/archive-release.yaml
+++ b/.github/workflows/archive-release.yaml
@@ -42,16 +42,16 @@ jobs:
       ENVOY_SHA: ${{ inputs.envoy_sha }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Install Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 
       - name: "Download macOS Apple Silicon binary"
         if: inputs.os == 'darwin'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: "envoy-${{ inputs.version }}-\
             darwin-arm64"
@@ -72,7 +72,7 @@ jobs:
           envoyproxy/envoy "${VERSION}"
 
       - name: "Upload GitHub Release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,25 @@
+# yamllint --format github .github/workflows/auto-release.yaml
+---
+name: "auto-release"
+
+on:
+  schedule:
+    - cron: '47 */6 * * *'  # Every 6 hours at :47
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Check for new Envoy releases"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          ./bin/check_releases.sh envoyproxy/envoy
+          ${{ github.repository }}

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -32,12 +32,12 @@ jobs:
       attestations: write
     steps:
       - name: "Check out Envoy source"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: envoyproxy/envoy
           ref: ${{ inputs.ref }}
 
-      - uses: bazel-contrib/setup-bazel@0.18.0
+      - uses: bazel-contrib/setup-bazel@0.19.0
 
       - name: "Configure GitHub auth for Bazel downloads"
         env:
@@ -64,12 +64,12 @@ jobs:
           strip bin/envoy
 
       - name: "Publish attestation to GitHub"
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: bin/envoy
 
       - name: "Upload Envoy binary"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: bin/envoy

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,7 +46,7 @@ jobs:
       ref: ${{ steps.resolve.outputs.ref }}
       compilation_mode: ${{ steps.resolve.outputs.compilation_mode }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Resolve inputs"
         id: resolve
@@ -107,7 +107,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ inputs.version }}
@@ -117,7 +117,7 @@ jobs:
     needs: archive-macos
     runs-on: macos-15-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ github.event.inputs.version }}
@@ -84,7 +84,7 @@ jobs:
     needs: archive-macos
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test-envoy
         with:
           version: ${{ github.event.inputs.version }}

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -24,7 +24,24 @@ branches. This keeps release count and maintenance bounded, and avoids
 notifying repository watchers daily.
 
 
+## Why does auto-release check Docker Hub before triggering?
+
+Envoy's Docker images appear on Docker Hub 3-6 hours after the GitHub release
+tag is created. The release workflow pulls binaries from
+`envoyproxy/envoy:vX.Y.Z`, so triggering before the image exists fails the
+job. Rather than add retry logic to the release workflow, the auto-release
+script checks the Docker Hub registry API and skips versions whose images are
+not ready. The 6-hour cron interval means those versions get picked up on the
+next run.
+
+## Why does auto-release fetch 10 releases?
+
+Envoy has never published more than 6 [releases][envoy-releases] in a single
+day. Fetching 10 gives margin while keeping Docker Hub checks to only what is
+actually new.
+
 ---
+[envoy-releases]: https://github.com/envoyproxy/envoy/blob/main/RELEASES.md
 [envoy-publish]: https://github.com/envoyproxy/envoy/blob/main/.github/workflows/envoy-publish.yml
 [dockerhub-dev]: https://hub.docker.com/r/envoyproxy/envoy/tags?name=dev-
 [dockerhub-debug-dev]: https://hub.docker.com/r/envoyproxy/envoy/tags?name=debug-dev-

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ A debug version has more information in the backtrace, and may lead to faster di
 ## Archiving a release
 Archiving a version means running [archive_release_version.sh](bin/archive_release_version.sh) for the version you want.
 
-This happens automatically in the [release workflow](https://github.com/tetratelabs/archive-envoy/actions/workflows/release.yaml)
-when given a valid version parameter (ex v1.18.3 or v1.18.3_debug).
+This happens automatically in the [auto-release workflow](.github/workflows/auto-release.yaml),
+which triggers the [release workflow](https://github.com/tetratelabs/archive-envoy/actions/workflows/release.yaml)
+for new Envoy versions.
 
-Ex. You can also run manually like this:
+You can also trigger a release manually:
 ```bash
 # optionally check first
 ./bin/archive_release_version.sh envoyproxy/envoy v1.18.3 check

--- a/bin/check_releases.sh
+++ b/bin/check_releases.sh
@@ -1,57 +1,72 @@
 #!/usr/bin/env bash
 
-# Copyright Archive Envoy
+# Copyright archive-envoy contributors
 # SPDX-License-Identifier: Apache-2.0
-# The full text of the Apache license is available in the LICENSE file at
-# the root of the repo.
 
 set -ue
 
-# This checks upstrean ${sourceGitHubRepository} releases and compares it
+# This checks upstream ${sourceGitHubRepository} releases and compares them
 # with the released versions on https://archive.tetratelabs.io/envoy/envoy-versions.json.
+# When a new version is found and its Docker image is available, it triggers
+# the release workflow for both production and debug builds.
+#
+# Fetches the 10 most recent releases via GraphQL (one API call) because
+# Envoy batches at most 6 patch releases on the same day.
 
-# Ensure we have tools we need installed
 curl --version >/dev/null
 jq --version >/dev/null
 gh --version >/dev/null
 
 sourceGitHubRepository=${1?sourceGitHubRepository is required. ex envoyproxy/envoy}
 targetGitHubRepository=${2?targetGitHubRepository is required. ex tetratelabs/archive-envoy}
-lowestVersion=${3?lowestVersion is required. ex 12.0.0}
 
-curl="curl -fsSL"
+sourceOwner=${sourceGitHubRepository%%/*}
+sourceName=${sourceGitHubRepository##*/}
 
-# A valid GitHub token to avoid rate limiting.
-githubToken=${GITHUB_TOKEN:-}
-# Prepare authorization header when performing request to api.github.com to avoid rate limiting, especially when testing locally.
-authorizationHeader="Authorization: Bearer ${githubToken}"
+docker_image_exists() {
+  local image=$1 tag=$2
+  local token
+  token=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${image}:pull" | jq -r '.token')
+  local status
+  status=$(curl -fsSL -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+    "https://registry-1.docker.io/v2/${image}/manifests/${tag}" 2>/dev/null)
+  [ "${status}" = "200" ]
+}
 
-# Always use the released versions.
-currentVersions=$(${curl} https://archive.tetratelabs.io/envoy/envoy-versions.json)
+versionsFile=$(mktemp)
+trap 'rm -f "${versionsFile}"' EXIT
+curl -fsSL https://archive.tetratelabs.io/envoy/envoy-versions.json > "${versionsFile}"
 
-# Fetch the last page number of releases (example value: 7), so we can get all of the releases.
-# To get the last page, we send a HEAD request to "https://api.github.com/repos/${sourceGitHubRepository}/releases",
-# then "grep" the "link" header value.
-# Reference: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers.
-lastReleasePage=$(${curl}I ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${sourceGitHubRepository}/releases" |
-  grep -Eo 'page=[0-9]+' | awk 'NR==2' | cut -d'=' -f2) || exit 1
+recentTags=$(gh api graphql \
+  -f owner="${sourceOwner}" \
+  -f name="${sourceName}" \
+  -f query='
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        releases(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+          nodes { tagName isDraft isPrerelease }
+        }
+      }
+    }
+  ' --jq '[.data.repository.releases.nodes[]
+    | select(.isDraft == false and .isPrerelease == false)
+    | .tagName]')
 
-for ((page = 1; page <= lastReleasePage; page++)); do
-  versions=$(${curl} ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${sourceGitHubRepository}/releases?page=${page}" |
-    jq -er ".|map(select(.prerelease == false and .draft == false))|.[]|.name" | sort -n) || exit 1
+newVersions=$(echo "${recentTags}" | jq -r \
+  --slurpfile archive "${versionsFile}" \
+  '.[] | ltrimstr("v") as $ver
+   | select($archive[0].versions | has($ver) | not)
+   | "v" + $ver' | sort -V)
 
-  for version in ${versions}; do
-    if [[ $(echo "${currentVersions}" | jq -r --arg ver "${version#v}" '.versions | has($ver)') == "true" ]]; then
-      continue
-    fi
+for version in ${newVersions}; do
+  if ! docker_image_exists envoyproxy/envoy "${version}"; then
+    echo "skipping ${version}: Docker image not yet available"
+    continue
+  fi
 
-    if [[ "$(echo -e "${version#v}\n${lowestVersion}" | sort -V | tail -n 1)" == "${version#v}" ]]; then
-      echo "creating release for"' '"${version}"
-      gh workflow run release.yaml -f version="${version}"_debug -R "${targetGitHubRepository}"
-      gh workflow run release.yaml -f version="${version}" -R "${targetGitHubRepository}"
-    fi
-
-    # TODO(dio): For macOS, we still need to check for https://ghcr.io/v2/homebrew/core/envoy/tags/list and see if
-    # our released JSON has darwin tarballs in it.
-  done
+  echo "creating release for ${version}"
+  ${DRY_RUN:-} gh workflow run release.yaml -f version="${version}"_debug -R "${targetGitHubRepository}"
+  ${DRY_RUN:-} gh workflow run release.yaml -f version="${version}" -R "${targetGitHubRepository}"
 done


### PR DESCRIPTION
Before this, archiving a new Envoy release required someone to manually run check_releases.sh or trigger release.yaml by hand. Versions sat unarchived until someone noticed.

Now a scheduled workflow polls every 6 hours, checks which versions are missing from envoy-versions.json, verifies the Docker Hub image is available, and triggers the release pipeline.

check_releases.sh uses a single GraphQL call to fetch the 10 most recent releases, filters against envoy-versions.json, and only checks Docker Hub for versions that are actually new.

To test locally without triggering real releases:

```bash
DRY_RUN=echo ./bin/check_releases.sh envoyproxy/envoy tetratelabs/archive-envoy
```
