### PR TITLE
Use strip -x on macOS to preserve dynamic module symbols

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -61,7 +61,7 @@ jobs:
           mkdir -p bin
           mv bazel-bin/source/exe/envoy-static bin/envoy
           chmod u+w bin/envoy
-          strip bin/envoy
+          strip -x bin/envoy
 
       - name: "Publish attestation to GitHub"
         uses: actions/attest-build-provenance@v4


### PR DESCRIPTION
Plain strip on macOS removes global symbols from the Mach-O export trie. This breaks dlsym lookups for envoy_dynamic_module_callback_* at runtime, causing null dereferences in Go and C dynamic modules.

strip -x removes only local symbols, keeping exported globals resolvable. Binary size is unchanged.

Closes #73