### PR TITLE
Use GraphQL and batch merge for version consolidation

### DIFF
--- a/bin/consolidate_release_versions.sh
+++ b/bin/consolidate_release_versions.sh
@@ -8,16 +8,17 @@
 set -ue
 
 # This creates a json file including all archived releases of a GitHub Repository.
-# Notably, this rewrites tarballURLs as permalinks
+# Notably, this rewrites tarball URLs as permalinks.
 
-# Ensure we have tools we need installed
 curl --version >/dev/null
 jq --version >/dev/null
 curl="curl -fsSL"
 
-# A valid GitHub token to avoid rate limiting.
 githubToken=${GITHUB_TOKEN:-}
-# Prepare authorization header when performing request to api.github.com to avoid rate limiting, especially when testing locally.
+if [ -z "${githubToken}" ]; then
+  echo >&2 "GITHUB_TOKEN is required for GraphQL API access"
+  exit 1
+fi
 authorizationHeader="Authorization: Bearer ${githubToken}"
 
 githubRepo="${1?-githubRepo required ex tetratelabs/archive-envoy}"
@@ -31,35 +32,62 @@ esac
 # This must match netlify.toml redirects
 redirectsTo="https://github.com/${githubRepo}/releases/download"
 
-# Fetch the last page number of releases (example value: 7), so we can get all of the releases.
-# To get the last page, we send a HEAD request to "https://api.github.com/repos/${githubRepo}/releases",
-# then "grep" the "link" header value.
-# Reference: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers.
-lastReleasePage=$(${curl}I ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${githubRepo}/releases" |
-  grep -Eo 'page=[0-9]+' | awk 'NR==2' | cut -d'=' -f2)
-lastReleasePage=${lastReleasePage:-1}
+owner="${githubRepo%%/*}"
+name="${githubRepo##*/}"
 
-# archive all dists for the version, generating the envoy-versions.json format incrementally
-releaseVersions="{}"
+# Fetch all release names via GraphQL (100 per page vs REST's 30).
+graphqlQuery='query($owner:String!,$name:String!,$cursor:String){repository(owner:$owner,name:$name){releases(first:100,orderBy:{field:CREATED_AT,direction:DESC},after:$cursor){pageInfo{hasNextPage endCursor}nodes{name isDraft isPrerelease}}}}'
 
-for ((page = 1; page <= lastReleasePage; page++)); do
-  # dev and dev_debug are prereleases, so they need explicit name matching to pass the filter.
-  versions=$(${curl} ${githubToken:+ -H "${authorizationHeader}"} "https://api.github.com/repos/${githubRepo}/releases?page=${page}" |
-    jq -er ".|map(select((.prerelease == false and .draft == false) or .name == \"dev\" or .name == \"dev_debug\"))|.[]|.name" | sort -n) || exit 1
+versions=""
+cursor="null"
+while true; do
+  requestBody=$(jq -n \
+    --arg query "${graphqlQuery}" \
+    --arg owner "${owner}" \
+    --arg name "${name}" \
+    --argjson cursor "${cursor}" \
+    '{query: $query, variables: {owner: $owner, name: $name, cursor: $cursor}}')
 
-  for version in ${versions}; do
-    # Exclusively handle debug.
-    case ${version} in v[0-9]*[0-9]_debug|dev_debug) nextDebugVersion=1 ;; *) unset nextDebugVersion;; esac
-    [ "${debugVersion:-}" != "${nextDebugVersion:-}" ] && continue
+  response=$(${curl} -H "${authorizationHeader}" \
+    -H "Content-Type: application/json" \
+    -d "${requestBody}" \
+    https://api.github.com/graphql) || exit 1
 
-    versionsUrl="${redirectsTo}/${version}/envoy-${version}.json"
-    nextReleaseVersion=$(${curl} "${versionsUrl}" | sed "s~${redirectsTo}~${downloadBaseURL}~g") || exit 1
-    # merge the pending releaseVersions json to include the next one.
-    releaseVersions=$(echo "${releaseVersions}" "${nextReleaseVersion}" | jq -Sse '.[0] * .[1]')
-  done
+  errors=$(echo "${response}" | jq -r '.errors[0].message // empty')
+  if [ -n "${errors}" ]; then
+    echo >&2 "GraphQL error: ${errors}"
+    exit 1
+  fi
+
+  versions+=$(echo "${response}" | jq -r '
+    [.data.repository.releases.nodes[]
+     | select((.isDraft == false and .isPrerelease == false)
+           or .name == "dev" or .name == "dev_debug")
+     | .name] | .[]')
+  versions+=$'\n'
+
+  hasNextPage=$(echo "${response}" | jq -r '.data.repository.releases.pageInfo.hasNextPage')
+  [ "${hasNextPage}" = "true" ] || break
+  cursor=$(echo "${response}" | jq '.data.repository.releases.pageInfo.endCursor')
 done
 
-# reorder top-level keys so that versions appear before sha256sums
+versions=$(echo "${versions}" | sort -n)
+
+# Download each version's JSON to a temp directory for a single batch merge.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+for version in ${versions}; do
+  case ${version} in v[0-9]*[0-9]_debug|dev_debug) nextDebugVersion=1 ;; *) unset nextDebugVersion;; esac
+  [ "${debugVersion:-}" != "${nextDebugVersion:-}" ] && continue
+
+  ${curl} "${redirectsTo}/${version}/envoy-${version}.json" > "${tmpdir}/${version}.json" || exit 1
+done
+
+# Merge all version JSONs in one pass, rewriting download URLs.
+releaseVersions=$(sed "s~${redirectsTo}~${downloadBaseURL}~g" "${tmpdir}"/*.json | \
+  jq -s 'reduce .[] as $x ({}; . * $x)')
+
 echo "${releaseVersions}" |\
-  jq '. | .latestVersion = ( .versions | keys | sort_by(split(".") | map(tonumber)) | last )' |\
+  jq '. | .latestVersion = ( .versions | keys | sort_by(gsub("_debug$";"") | split(".") | map(tonumber)) | last )' |\
   jq '{latestVersion, versions, sha256sums} + (if .dev then {dev} else {} end)'


### PR DESCRIPTION
GraphQL lists 100 releases per page vs REST's 30, reducing listing from ~13 API calls to ~4. Downloading all per-version JSONs to a temp directory and merging in one jq reduce pass replaces the incremental O(n^2) merge. Also fixes the _debug suffix crash in latestVersion sort_by (envoy-versions_debug.json has been empty since #72 merged).

GITHUB_TOKEN is now required because GraphQL needs authentication. Netlify already has this configured (see netlify.toml).