### PR TITLE
Replace per-version JSON downloads with GraphQL digests

### DIFF
--- a/.github/workflows/archive-release.yaml
+++ b/.github/workflows/archive-release.yaml
@@ -65,11 +65,16 @@ jobs:
           "${VERSION}"/envoy-"${VERSION}"-darwin-arm64/bin/envoy
 
       - name: "Archive Envoy Release"
+        id: archive
         env:
           ARCHIVE_OS: ${{ inputs.os }}
-        run: >-
-          ./bin/archive_release_version.sh
-          envoyproxy/envoy "${VERSION}"
+        run: |
+          body=$(./bin/archive_release_version.sh envoyproxy/envoy "${VERSION}")
+          {
+            echo "body<<EOF"
+            echo "${body}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: "Upload GitHub Release"
         uses: softprops/action-gh-release@v3
@@ -77,10 +82,7 @@ jobs:
           tag_name: ${{ inputs.version }}
           prerelease: ${{ inputs.prerelease }}
           files: ${{ inputs.version }}/*
-          body: >-
-            ${{ inputs.envoy_sha != ''
-            && format('envoy_sha={0}', inputs.envoy_sha)
-            || '' }}
+          body: ${{ steps.archive.outputs.body }}
 
       - name: "Trigger Netlify deploy"
         if: >-

--- a/bin/archive_release_version.sh
+++ b/bin/archive_release_version.sh
@@ -113,7 +113,7 @@ fi
 export RELEASE_DATE
 tarxz="${tar} --numeric-owner --owner 65534 --group 65534 --mtime ${RELEASE_DATE?-ex. 2021-05-11} -cpJf"
 
-echo "archiving ${sourceGitHubRepository} ${version} released on ${RELEASE_DATE}"
+echo >&2 "archiving ${sourceGitHubRepository} ${version} released on ${RELEASE_DATE}"
 # archive all dists for the version, generating https://archive.tetratelabs.io/release-versions-schema.json incrementally
 releaseVersions="{}"
 archiveRepo=${GITHUB_REPOSITORY:-tetratelabs/archive-envoy}
@@ -127,10 +127,10 @@ for os in darwin linux; do
     [ "${os}" = 'darwin' ] && [ "${arch}" = 'amd64' ] && continue
 
     dist="envoy-${version}-${os}-${arch}"
-    echo "using dist: ${dist}"
+    echo >&2 "using dist: ${dist}"
 
     if [ -d "${version}/${dist}" ]; then
-      echo "using existing dist"
+      echo >&2 "using existing dist"
     else
       # permit a version to fail rather than duplicating maintenance here and in archive_release.sh
       set +e
@@ -145,7 +145,7 @@ for os in darwin linux; do
     fi
 
     archive="${dist}.tar.xz"
-    echo "creating ${archive}"
+    echo >&2 "creating ${archive}"
     (cd "${version}" && ${tarxz} "${archive}" "${dist}")
     rm -rf "${version}/${dist}"
     s=$(sha256sum "${version}/${archive}" | awk '{print $1}') || exit 1
@@ -191,3 +191,9 @@ esac
 echo "${releaseVersions}" >"${version}/${name}-${version}.json"
 touchDate=$(echo "${RELEASE_DATE}"|sed 's/-//g')0000
 find "${version}" -exec touch -t "${touchDate}" {} \;
+
+# Emit the release body to stdout for the caller to capture.
+if [ -n "${envoy_sha:-}" ]; then
+  echo "envoy_sha=${envoy_sha}"
+fi
+echo "envoy_release_date=${RELEASE_DATE}"

--- a/bin/check_releases.sh
+++ b/bin/check_releases.sh
@@ -62,11 +62,11 @@ newVersions=$(echo "${recentTags}" | jq -r \
 
 for version in ${newVersions}; do
   if ! docker_image_exists envoyproxy/envoy "${version}"; then
-    echo "skipping ${version}: Docker image not yet available"
+    echo >&2 "skipping ${version}: Docker image not yet available"
     continue
   fi
 
-  echo "creating release for ${version}"
+  echo >&2 "creating release for ${version}"
   ${DRY_RUN:-} gh workflow run release.yaml -f version="${version}"_debug -R "${targetGitHubRepository}"
   ${DRY_RUN:-} gh workflow run release.yaml -f version="${version}" -R "${targetGitHubRepository}"
 done

--- a/bin/consolidate_release_versions.sh
+++ b/bin/consolidate_release_versions.sh
@@ -9,13 +9,17 @@ set -ue
 
 # This creates a json file including all archived releases of a GitHub Repository.
 # Notably, this rewrites tarball URLs as permalinks.
+#
+# Release metadata (releaseDate, commitSha) is read from each release's
+# description field, and sha256sums from asset digests. No per-version JSON
+# downloads are needed.
 
 curl --version >/dev/null
 jq --version >/dev/null
 curl="curl -fsSL"
 
 githubToken=${GITHUB_TOKEN:-}
-if [ -z "${githubToken}" ]; then
+if [ -z "${githubToken}" ] && [ -z "${RELEASES_JSON:-}" ]; then
   echo >&2 "GITHUB_TOKEN is required for GraphQL API access"
   exit 1
 fi
@@ -35,59 +39,111 @@ redirectsTo="https://github.com/${githubRepo}/releases/download"
 owner="${githubRepo%%/*}"
 name="${githubRepo##*/}"
 
-# Fetch all release names via GraphQL (100 per page vs REST's 30).
-graphqlQuery='query($owner:String!,$name:String!,$cursor:String){repository(owner:$owner,name:$name){releases(first:100,orderBy:{field:CREATED_AT,direction:DESC},after:$cursor){pageInfo{hasNextPage endCursor}nodes{name isDraft isPrerelease}}}}'
+releasesJson=${RELEASES_JSON:-}
+if [ -n "${releasesJson}" ]; then
+  allReleases=$(cat "${releasesJson}")
+else
+  # Fetch all releases with assets and digests via GraphQL (100 per page).
+  graphqlQuery='query($owner:String!,$name:String!,$cursor:String){repository(owner:$owner,name:$name){releases(first:100,orderBy:{field:CREATED_AT,direction:DESC},after:$cursor){pageInfo{hasNextPage endCursor}nodes{tagName isDraft isPrerelease description releaseAssets(first:10){nodes{name digest downloadUrl}}}}}}'
 
-versions=""
-cursor="null"
-while true; do
-  requestBody=$(jq -n \
-    --arg query "${graphqlQuery}" \
-    --arg owner "${owner}" \
-    --arg name "${name}" \
-    --argjson cursor "${cursor}" \
-    '{query: $query, variables: {owner: $owner, name: $name, cursor: $cursor}}')
+  allReleases="[]"
+  cursor="null"
+  while true; do
+    requestBody=$(jq -n \
+      --arg query "${graphqlQuery}" \
+      --arg owner "${owner}" \
+      --arg name "${name}" \
+      --argjson cursor "${cursor}" \
+      '{query: $query, variables: {owner: $owner, name: $name, cursor: $cursor}}')
 
-  response=$(${curl} -H "${authorizationHeader}" \
-    -H "Content-Type: application/json" \
-    -d "${requestBody}" \
-    https://api.github.com/graphql) || exit 1
+    response=$(${curl} -H "${authorizationHeader}" \
+      -H "Content-Type: application/json" \
+      -d "${requestBody}" \
+      https://api.github.com/graphql) || exit 1
 
-  errors=$(echo "${response}" | jq -r '.errors[0].message // empty')
-  if [ -n "${errors}" ]; then
-    echo >&2 "GraphQL error: ${errors}"
-    exit 1
-  fi
+    errors=$(echo "${response}" | jq -r '.errors[0].message // empty')
+    if [ -n "${errors}" ]; then
+      echo >&2 "GraphQL error: ${errors}"
+      exit 1
+    fi
 
-  versions+=$(echo "${response}" | jq -r '
-    [.data.repository.releases.nodes[]
-     | select((.isDraft == false and .isPrerelease == false)
-           or .name == "dev" or .name == "dev_debug")
-     | .name] | .[]')
-  versions+=$'\n'
+    allReleases=$(echo "${allReleases}" "${response}" | jq -s '
+      .[0] + [.[1].data.repository.releases.nodes[]
+        | select((.isDraft == false and .isPrerelease == false)
+              or .tagName == "dev" or .tagName == "dev_debug")]')
 
-  hasNextPage=$(echo "${response}" | jq -r '.data.repository.releases.pageInfo.hasNextPage')
-  [ "${hasNextPage}" = "true" ] || break
-  cursor=$(echo "${response}" | jq '.data.repository.releases.pageInfo.endCursor')
-done
+    hasNextPage=$(echo "${response}" | jq -r '.data.repository.releases.pageInfo.hasNextPage')
+    [ "${hasNextPage}" = "true" ] || break
+    cursor=$(echo "${response}" | jq '.data.repository.releases.pageInfo.endCursor')
+  done
+fi
 
-versions=$(echo "${versions}" | sort -n)
+# Transform GraphQL data into the consolidated release-versions JSON.
+echo "${allReleases}" | jq \
+  --arg debugVersion "${debugVersion}" \
+  --arg redirectsTo "${redirectsTo}" \
+  --arg downloadBaseURL "${downloadBaseURL}" \
+'
+# Filter by debug flag
+[ .[] |
+  (.tagName | test("_debug$")) as $isDebug |
+  (.tagName == "dev_debug") as $isDevDebug |
+  ($isDebug or $isDevDebug) as $isAnyDebug |
+  select(
+    if $debugVersion == "1" then $isAnyDebug
+    else ($isAnyDebug | not)
+    end
+  )
+] |
 
-# Download each version's JSON to a temp directory for a single batch merge.
-tmpdir=$(mktemp -d)
-trap 'rm -rf "${tmpdir}"' EXIT
+# Build versions, sha256sums, and dev from release data
+reduce .[] as $r ({versions: {}, sha256sums: {}};
+  $r.tagName as $tag |
+  ($r.description // "") as $desc |
 
-for version in ${versions}; do
-  case ${version} in v[0-9]*[0-9]_debug|dev_debug) nextDebugVersion=1 ;; *) unset nextDebugVersion;; esac
-  [ "${debugVersion:-}" != "${nextDebugVersion:-}" ] && continue
+  # Parse envoy_release_date= from description
+  (if $desc | test("envoy_release_date=") then $desc | capture("envoy_release_date=(?<d>[0-9]{4}-[0-9]{2}-[0-9]{2})") | .d else null end) as $date |
 
-  ${curl} "${redirectsTo}/${version}/envoy-${version}.json" > "${tmpdir}/${version}.json" || exit 1
-done
+  # Tarball assets only
+  [$r.releaseAssets.nodes[] | select(.name | endswith(".tar.xz"))] as $tarballs |
 
-# Merge all version JSONs in one pass, rewriting download URLs.
-releaseVersions=$(sed "s~${redirectsTo}~${downloadBaseURL}~g" "${tmpdir}"/*.json | \
-  jq -s 'reduce .[] as $x ({}; . * $x)')
+  # Build tarballs map: "os/arch" -> rewritten URL
+  ($tarballs | reduce .[] as $a ({};
+    ($a.name | ltrimstr("envoy-" + $tag + "-") | rtrimstr(".tar.xz") | split("-") | .[0] + "/" + .[1]) as $platform |
+    ($a.downloadUrl | sub($redirectsTo; $downloadBaseURL)) as $url |
+    . + {($platform): $url}
+  )) as $tarballMap |
 
-echo "${releaseVersions}" |\
-  jq '. | .latestVersion = ( .versions | keys | sort_by(gsub("_debug$";"") | split(".") | map(tonumber)) | last )' |\
-  jq '{latestVersion, versions, sha256sums} + (if .dev then {dev} else {} end)'
+  # Build sha256sums from digests
+  ($tarballs | reduce .[] as $a ({};
+    if $a.digest != null and ($a.digest | startswith("sha256:")) then
+      . + {($a.name): ($a.digest | ltrimstr("sha256:"))}
+    else . end
+  )) as $sums |
+
+  if ($tag == "dev" or $tag == "dev_debug") then
+    # Dev builds go under .dev with commitSha
+    (if $desc | test("envoy_sha=") then $desc | capture("envoy_sha=(?<s>[0-9a-f]{40})") | .s else null end) as $commitSha |
+    .dev = (
+      {releaseDate: $date, tarballs: $tarballMap}
+      + if $commitSha then {commitSha: $commitSha} else {} end
+    ) |
+    .sha256sums += $sums
+  else
+    # Regular versions go under .versions[key]
+    ($tag | ltrimstr("v")) as $versionKey |
+    .versions[$versionKey] = {releaseDate: $date, tarballs: $tarballMap} |
+    .sha256sums += $sums
+  end
+) |
+
+# Calculate latestVersion
+.latestVersion = (
+  .versions | keys |
+  sort_by(gsub("_debug$";"") | split(".") | map(tonumber)) |
+  last
+) |
+
+# Select output keys in schema order
+{latestVersion, versions, sha256sums} + (if .dev then {dev} else {} end)
+'


### PR DESCRIPTION
Netlify builds downloaded ~216 per-version JSON files per invocation to get sha256sums and release dates. Now that all release assets have sha256 digests in GraphQL (backfilled in a prior change), the consolidation script reads everything from a single paginated GraphQL query: tarballs from asset names, sha256sums from asset digests, release dates from a new envoy_release_date field in each release description, and commitSha from the existing envoy_sha field.

This reduces network calls per build from ~440 to ~8.

archive-release.yaml now writes envoy_release_date= to the release description so future releases are covered without a separate backfill.