### PR TITLE
Smoke tests should not depend on release asset availability

### DIFF
--- a/.github/actions/test-envoy/action.yaml
+++ b/.github/actions/test-envoy/action.yaml
@@ -2,26 +2,30 @@ name: "Test Envoy binary"
 description: "Download a release tarball and verify the binary runs"
 inputs:
   version:
-    description: "Release tag to download"
+    description: "Version to test (e.g. v1.34.1, dev, dev_debug)"
     required: true
 runs:
   using: composite
   steps:
     - shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
+      id: resolve
       run: |
         case "${{ runner.os }}" in
-          Linux)  os=linux  ;;
-          macOS)  os=darwin ;;
+          Linux)  echo "os=linux"  >> "$GITHUB_OUTPUT" ;;
+          macOS)  echo "os=darwin" >> "$GITHUB_OUTPUT" ;;
         esac
         case "${{ runner.arch }}" in
-          X64)    arch=amd64 ;;
-          ARM64)  arch=arm64 ;;
+          X64)    echo "arch=amd64" >> "$GITHUB_OUTPUT" ;;
+          ARM64)  echo "arch=arm64" >> "$GITHUB_OUTPUT" ;;
         esac
-        pattern="*-${os}-${arch}.tar.xz"
-        gh release -R "${GITHUB_REPOSITORY}" download \
-          "${{ inputs.version }}" -p "${pattern}"
-        tar --strip-components=2 -xpJf ./*.tar.xz && rm ./*.tar.xz
+    - uses: actions/download-artifact@v8
+      with:
+        name: "tarballs-${{ inputs.version }}-\
+          ${{ steps.resolve.outputs.os }}"
+        path: dist
+    - shell: bash
+      run: >-
+        tar --strip-components=2 -xpJf
+        dist/*-${{ steps.resolve.outputs.os }}-${{ steps.resolve.outputs.arch }}.tar.xz
     - shell: bash
       run: ./envoy --version

--- a/.github/workflows/archive-release.yaml
+++ b/.github/workflows/archive-release.yaml
@@ -76,6 +76,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: "Upload tarballs for testing"
+        uses: actions/upload-artifact@v7
+        with:
+          name: "tarballs-${{ inputs.version }}-${{ inputs.os }}"
+          path: "${{ inputs.version }}/*.tar.xz"
+
       - name: "Upload GitHub Release"
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
The archive step now uploads tarballs as workflow artifacts so tests download them directly, avoiding races with the GitHub release upload.